### PR TITLE
Update organization references to opencadc-metadata-curation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM opencadc/pandas:3.10-slim as builder
+FROM opencadc-metadata-curation/pandas:3.10-slim as builder
 
 RUN apt-get update --no-install-recommends && \
     apt-get dist-upgrade -y && \
@@ -8,9 +8,9 @@ RUN apt-get update --no-install-recommends && \
 ARG CAOM2_BRANCH=master
 ARG CAOM2_REPO=opencadc
 ARG GEM_BRANCH=master
-ARG GEM_REPO=opencadc
+ARG GEM_REPO=opencadc-metadata-curation
 ARG PIPE_BRANCH=master
-ARG PIPE_REPO=opencadc
+ARG PIPE_REPO=opencadc-metadata-curation
 
 RUN git clone https://github.com/${CAOM2_REPO}/caom2tools.git && \
     cd caom2tools && \

--- a/scripts/gem_proc_run.sh
+++ b/scripts/gem_proc_run.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 COLLECTION="gem_proc"
-IMAGE="opencadc/${COLLECTION}2caom2"
+IMAGE="opencadc-metadata-curation/${COLLECTION}2caom2"
 
 echo "Get a proxy certificate"
 cp $HOME/.ssl/cadcproxy.pem ./ || exit $?

--- a/setup.cfg
+++ b/setup.cfg
@@ -36,7 +36,7 @@ author_email = cadc@nrc-cnrc.gc.ca
 license = AGPLv3
 url = TBD
 edit_on_github = False
-github_project = opencadc/gemProc2caom2
+github_project = opencadc-metadata-curation/gemProc2caom2
 install_requires =
     matplotlib
 # version should be PEP386 compatible (http://www.python.org/dev/peps/pep-0386)


### PR DESCRIPTION
This PR updates all references from `opencadc` to `opencadc-metadata-curation` following the repository transfer.

## Changes
- Updated Dockerfile dependencies and base images\n- Updated shell scripts\n
## Files Modified
```
Dockerfile
scripts/gem_proc_run.sh
```

## Related
- Repository migration to opencadc-metadata-curation organization
- Ensures all references point to the correct organization

## Testing
- Verify builds pass
- Verify all references are updated correctly
