### PR TITLE
Update Dockerfile ARG variables for organization migration

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,9 +8,9 @@ RUN apt-get update --no-install-recommends && \
 ARG CAOM2_BRANCH=master
 ARG CAOM2_REPO=opencadc
 ARG GEM_BRANCH=master
-ARG GEM_REPO=opencadc
+ARG GEM_REPO=opencadc-metadata-curation
 ARG PIPE_BRANCH=master
-ARG PIPE_REPO=opencadc
+ARG PIPE_REPO=opencadc-metadata-curation
 
 RUN git clone https://github.com/${CAOM2_REPO}/caom2tools.git && \
     cd caom2tools && \

--- a/setup.cfg
+++ b/setup.cfg
@@ -36,7 +36,7 @@ author_email = cadc@nrc-cnrc.gc.ca
 license = AGPLv3
 url = TBD
 edit_on_github = False
-github_project = opencadc/gemProc2caom2
+github_project = opencadc-metadata-curation/gemProc2caom2
 install_requires =
     matplotlib
 # version should be PEP386 compatible (http://www.python.org/dev/peps/pep-0386)


### PR DESCRIPTION
## Summary
Update Dockerfile ARG variables to reflect the repository transfer from opencadc to opencadc-metadata-curation organization.

## Changes
- Update PIPE_REPO from opencadc to opencadc-metadata-curation

This ensures pip install commands correctly reference the new repository location:
```
pip install git+https://github.com/opencadc-metadata-curation/gemProc2caom2
```

Note: Docker base image references (FROM opencadc/...) remain unchanged as those are still hosted under the opencadc organization.